### PR TITLE
Fix threecol layout in Roundcube 1.0.x.

### DIFF
--- a/skins/larry/func.php
+++ b/skins/larry/func.php
@@ -9,21 +9,17 @@ function render_page($args)
 {
 	$patterns = array();
 	$patterns[0] = '/#mailview-top \{ height: [0-9]+px; \}/';
-	$patterns[1] = '/#mailview-bottom \{ top: [0-9]+px; height: auto; \}/';
+	$patterns[1] = '/#mailview-bottom \{ top: [0-9]+px; height: auto; display: block; \}/';
 	$patterns[2] = '/id="mailview-top"/';
 	$patterns[3] = '/id="mailview-bottom"/';
-	$patterns[4] = '/<div id="message" class="statusbar"><\/div>/';
-	$patterns[5] = '/<\/div><\!\-\- end mailview\-top \-\->/';
-	$patterns[6] = '/UI.init\(\);/';
+	$patterns[4] = '/UI.init\(\);/';
 
 	$replacements = array();
 	$replacements[0] = '#mailview-tc-mid { width: ' . (!empty($_COOKIE['mailviewsplittertc']) ? $_COOKIE['mailviewsplittertc']-5 : 700) . 'px; }';
 	$replacements[1] = '#mailview-tc-right { left: ' . (!empty($_COOKIE['mailviewsplittertc']) ? $_COOKIE['mailviewsplittertc']+7 : 700) . 'px; display: block; }';
 	$replacements[2] = 'id="mailview-tc-mid"';
 	$replacements[3] = 'id="mailview-tc-right"';
-	$replacements[4] = '';
-	$replacements[5] = '<div id="message" class="statusbar"></div></div><!-- end mailview-top -->';
-	$replacements[6] = 'UI.init(); init_threecol_splitter();';
+	$replacements[4] = 'UI.init(); init_threecol_splitter();';
 
 	$args['content'] = preg_replace($patterns, $replacements, $args['content']);
 


### PR DESCRIPTION
The base template in skins/larry has changed, so the evil
regexp substiution on the full page content in this plugin
needs to be updated to match.

It might make sense to have two sets of substitutions depending
on the Roundcube version.
